### PR TITLE
Add config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,7 @@ DerivedData/
 .DS_Store
 
 ## Configration files
-*.xcconfig
+## *.xcconfig
 
 ## Playgrounds
 timeline.xctimeline

--- a/Papcorns101.xcodeproj/xcuserdata/deniz.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/Papcorns101.xcodeproj/xcuserdata/deniz.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Bucket
+   uuid = "A09496C2-E000-4ECC-BD29-FFADA586023E"
+   type = "1"
+   version = "2.0">
+</Bucket>

--- a/Papcorns101/Production.xcconfig
+++ b/Papcorns101/Production.xcconfig
@@ -1,0 +1,11 @@
+//
+//  Production.xcconfig
+//  Papcorns101
+//
+//  Created by Deniz Çakmakçı on 3.11.2024.
+//
+
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974
+
+BASE_URL = us-central1-ai-video-40ecf.cloudfunctions.net/


### PR DESCRIPTION
The configration file has been added so that a remote person can install the repo without errors, and the rule added for files with ".xcconfig" extension from .gitignore has been removed.